### PR TITLE
Introduce qb-logs hook into fm-logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ A logging resource for your FiveM server that logs directly to [Fivemerr's](http
 - Explosion Logs
 - TxAdmin Logs
 - Screenshot Logs
+- Framework Logs (Only QB is supported at this moment)
 
 # Preview
 ![image](https://github.com/user-attachments/assets/7d322f05-39ba-4dea-b52a-db7b7f8e1d13)
@@ -76,6 +77,15 @@ Framework = "qb", -- "qb" | "esx" | "standalone"
 ```
 
 If you do not use a framework, simply set this to "standalone".
+
+### QB Core
+
+We now support `qb-logs` without having to alter `qb-smallresources` directly. To enable this, set the following configuration variable values:
+
+```
+Config.Framework = "qb"
+Config.Logs.Framework = true
+```
 
 # Credits 
 * [iratetech](https://github.com/ir8scripts)

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -1,4 +1,4 @@
-version '1.0.0'
+version '1.0.1'
 author 'Fivemerr'
 description 'FXServer logs to Fivemerr'
 repository 'https://github.com/FiveMerr/fm-logs'
@@ -10,6 +10,7 @@ server_script {
     'server/logger.lua',
     'server/main.lua',
     'server/events/*.lua',
+    'server/framework/*lua',
     'server/exports.lua'
 }
 

--- a/server/framework/qb.lua
+++ b/server/framework/qb.lua
@@ -1,0 +1,27 @@
+-------------------------------------------------
+--- QB CORE LOGS
+--- Event handler for qb-logs
+-------------------------------------------------
+if Config.Logs.Framework and Config.Framework == "qb" then
+    AddEventHandler('qb-log:server:CreateLog', function(name, title, color, message, tagEveryone, imageUrl)
+
+        -- Events from QB to exclude
+        local EventsToExclude = {
+            "SetInventory"
+        }
+
+        -- If excluded
+        if Logger.TableHasValue(EventsToExclude, title) then return end
+
+        -- Create the log with the data passed from qb-log
+        Logger.CreateLog({
+            LogType = "QBCore",
+            Level = tagEveryone and 'warn' or 'info',
+            Message = title .. " - " .. message:gsub("*", ""),
+            Resource = "qb-logs",
+            Metadata = {
+                image = imageUrl
+            }
+        })
+    end)
+end

--- a/server/logger.lua
+++ b/server/logger.lua
@@ -94,8 +94,15 @@ Logger = {
 
         -- Depending on log type, convert metadata to lines
         if data.LogType ~= "Resource" then
-            logData.message = logData.message .. "\r\n-------------------------------------------------\r\n"
-            logData.message = logData.message .. Logger.ConvertLogToLines(logData.metadata)
+
+            -- Only include the meta data in the message payload
+            -- if it has more than one key:value pair.
+            if logData.metadata then
+                if #logData.metadata > 1 then
+                    logData.message = logData.message .. "\r\n-------------------------------------------------\r\n"
+                    logData.message = logData.message .. Logger.ConvertLogToLines(logData.metadata)
+                end
+            end
         end
 
         -- Submit the request

--- a/shared/config.lua
+++ b/shared/config.lua
@@ -5,7 +5,7 @@ Config = {
 
     -- Framework for logging player names
     -- Standalone uses server player name
-    Framework = "standalone", -- "qb" | "esx" | "standalone"
+    Framework = "qb", -- "qb" | "esx" | "standalone"
 
     -- Event prefixes
     ClientEventPrefix = GetCurrentResourceName() .. ":Client:",
@@ -35,6 +35,7 @@ Config = {
         System = true, -- System logs
         TxAdmin = true, -- TxAdmin logs
         Screenshot = true, -- Screenshot logs
+        Framework = true, -- Will log framework logs if applicable
 
         -- The following attributes will be included in 
         -- the log meta data if true.

--- a/shared/config.lua
+++ b/shared/config.lua
@@ -5,7 +5,7 @@ Config = {
 
     -- Framework for logging player names
     -- Standalone uses server player name
-    Framework = "qb", -- "qb" | "esx" | "standalone"
+    Framework = "standalone", -- "qb" | "esx" | "standalone"
 
     -- Event prefixes
     ClientEventPrefix = GetCurrentResourceName() .. ":Client:",
@@ -35,7 +35,7 @@ Config = {
         System = true, -- System logs
         TxAdmin = true, -- TxAdmin logs
         Screenshot = true, -- Screenshot logs
-        Framework = true, -- Will log framework logs if applicable
+        Framework = false, -- Will log framework logs if applicable
 
         -- The following attributes will be included in 
         -- the log meta data if true.


### PR DESCRIPTION
Utilize an event listener to listen for `qb-log:server:CreateLog` to prevent having to alter `qb-smallresources` directly.

To enable this, set the following configuration variable values:

```
Config.Framework = "qb"
Config.Logs.Framework = true
```

Other updates:

- Metadata is no longer converted to new lines for the message payload unless it has more than 1 key:value pair. This prevents the long line of dashes on a normal log that doesn't carry metadata.