### PR TITLE
[1.0.2] Moves API Token to Convar

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,16 @@ A logging resource for your FiveM server that logs directly to [Fivemerr's](http
 
 - FXServer With at least build: `5562`
 - [screenshot-basic](https://github.com/citizenfx/screenshot-basic)
+- [ox_lib](https://github.com/overextended/ox_lib)
 
 # Installation
-* Add your Fivemer Logs API Key on `server > main.lua` line 2.
-* Configure your framework or standalone on `shared > config.lua` line 8. 
+1. Add your Fivemer Logs API token to `server.cfg`
+```
+# Fivemerr Api Token
+set fivemerr:apyToken "token"
+```
+
+2. Configure your framework or standalone on `shared > config.lua` line 8. 
 
 # Features
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A logging resource for your FiveM server that logs directly to [Fivemerr's](http
 1. Add your Fivemer Logs API token to `server.cfg`
 ```
 # Fivemerr Api Token
-set fivemerr:apyToken "token"
+set fivemerr:apiToken "token"
 ```
 
 2. Configure your framework or standalone on `shared > config.lua` line 8. 

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -1,4 +1,4 @@
-version '1.0.1'
+version '1.0.2'
 author 'Fivemerr'
 description 'FXServer logs to Fivemerr'
 repository 'https://github.com/FiveMerr/fm-logs'

--- a/server/events/txadmin.lua
+++ b/server/events/txadmin.lua
@@ -26,6 +26,23 @@ AddEventHandler('txAdmin:events:scheduledRestart', function(data)
     })
 end)
 
+-- DM logs
+AddEventHandler('txAdmin:events:playerDirectMessage', function(data)
+    -- If this log is not enabled, just return early
+    if not Config.Logs.TxAdmin then return end
+
+    
+    Logger.CreateLog({
+        LogType = "TxAdmin",
+        Message = "Player DM",
+        Metadata = {
+            name = names[data.target],
+            author = data.author,
+            message = data.message
+        }
+    })
+end)
+
 -- When a player is kicked
 AddEventHandler('txAdmin:events:playerKicked', function(data)
 	-- If this log is not enabled, just return early

--- a/server/framework/qb.lua
+++ b/server/framework/qb.lua
@@ -15,7 +15,7 @@ if Config.Logs.Framework and Config.Framework == "qb" then
 
         -- Create the log with the data passed from qb-log
         Logger.CreateLog({
-            LogType = "QBCore",
+            LogType = "Framework",
             Level = tagEveryone and 'warn' or 'info',
             Message = title .. " - " .. message:gsub("*", ""),
             Resource = "qb-logs",

--- a/server/main.lua
+++ b/server/main.lua
@@ -1,5 +1,6 @@
--- Your API key for Fivemerr
-FivemerrApiKey = "token"
+-------------------------------------------------
+--- Setup
+-------------------------------------------------
 
 -- API Urls
 FivemerrApiUrls = {
@@ -10,15 +11,37 @@ FivemerrApiUrls = {
 -- Load the language locales
 Language.SetLanguage(Config.Language).LoadLocales()
 
+-------------------------------------------------
+--- Logger status / version
+-------------------------------------------------
+
+-- Get the version
 local version = GetResourceMetadata(GetCurrentResourceName(), 'version')
 
+-- Output the status of the logger
 print('--------------------------------------------------')
 print('|                                                |')
 print('|                 FIVEMERR LOGGER                |')
-print('|                     STARTED                    |')
+
+-- Check if api token is set
+if not Logger.RetrieveApiToken() then
+    print('|                   ^1NOT STARTED^0                  |')
+else
+    print('|                     ^2STARTED^0                    |')
+end
+
 print('|                  VERSION ' .. version .. '                 |')
 print('|                                                |')
 print('--------------------------------------------------')
+
+-- If the api token is not set
+if not Logger.RetrieveApiToken() then
+    Logger.ApiTokenError()
+end
+
+-------------------------------------------------
+--- Callbacks
+-------------------------------------------------
 
 -- Return locales from language state
 lib.callback.register(Config.ServerEventPrefix .. 'retrieveLocales', function ()


### PR DESCRIPTION
- Moves API Token to Convar
- Cleans up mentions of "api key" and changes it to "api token" for better clarity.
- Updated framework logs and how it determines metadata being included in messages.
- Status of fm-logger print has been updated based on api token and whether it could be retrieved
- Now outputs the "api token could not be found" error immediately after the resource tries to start if not found.

**Note: Incrementing version due to moving of api token**

![image](https://github.com/user-attachments/assets/3020bc84-2ba6-40df-9260-c2e198e75e39)
